### PR TITLE
Make coveralls a runtime dependency

### DIFF
--- a/pry-test.gemspec
+++ b/pry-test.gemspec
@@ -14,8 +14,8 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 1.9.2"
   spec.extensions            = "ext/mkrf_conf.rb"
   spec.add_dependency "os"
+  spec.add_dependency "coveralls"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "coveralls"
 
   # spec.add_dependency "pry"
   # spec.add_dependency "pry-stack_explorer"


### PR DESCRIPTION
When executing the instructions in the README, I got a load error:

```
/Users/jh/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- coveralls (LoadError)
    from /Users/jh/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/jh/Code/Ruby/pry-test/test/test_helper.rb:1:in `<top (required)>'
    from /Users/jh/Code/Ruby/pry-test/test/cpu_latency_test.rb:2:in `require_relative'
    from /Users/jh/Code/Ruby/pry-test/test/cpu_latency_test.rb:2:in `<top (required)>'
    from /Users/jh/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /Users/jh/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from ./bin/pry-test:59:in `block in <main>'
    from ./bin/pry-test:59:in `each'
    from ./bin/pry-test:59:in `<main>'
```

By making Coveralls a runtime dependency, this won't be an issue. Let me know if this causes other issues I'm not aware of.
